### PR TITLE
Discard master and slave jargon

### DIFF
--- a/excute/migrations/0001_initial.py
+++ b/excute/migrations/0001_initial.py
@@ -98,12 +98,12 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='dbms',
-            name='master',
+            name='main',
             field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='excute.Services', verbose_name='\u4e3b\u5e93'),
         ),
         migrations.AddField(
             model_name='dbms',
-            name='slave',
+            name='subordinate',
             field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='pk', to='excute.Services', verbose_name='\u4ece\u5e93'),
         ),
     ]

--- a/excute/migrations/0002_auto_20180922_2003.py
+++ b/excute/migrations/0002_auto_20180922_2003.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterField(
             model_name='dbms',
-            name='slave',
+            name='subordinate',
             field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='uuid', to='excute.Services', verbose_name='\u4ece\u5e93'),
         ),
     ]

--- a/excute/migrations/0003_auto_20180922_2009.py
+++ b/excute/migrations/0003_auto_20180922_2009.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterField(
             model_name='dbms',
-            name='slave',
+            name='subordinate',
             field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='pk', to='excute.Services', verbose_name='\u4ece\u5e93'),
         ),
     ]

--- a/excute/migrations/0004_auto_20180922_2011.py
+++ b/excute/migrations/0004_auto_20180922_2011.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterField(
             model_name='dbms',
-            name='slave',
+            name='subordinate',
             field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='uuid', to='excute.Services', verbose_name='\u4ece\u5e93'),
         ),
     ]

--- a/excute/models.py
+++ b/excute/models.py
@@ -103,7 +103,7 @@ class Services(models.Model):
         (3, u'other'),
     )
     # to_db = models.ForeignKey('self', related_name='uuid', verbose_name='to_db', blank=True, null=True)
-    # to_slave_db = models.ForeignKey('self', verbose_name='slave-db', blank=True, null=True)
+    # to_subordinate_db = models.ForeignKey('self', verbose_name='subordinate-db', blank=True, null=True)
     install_way = models.PositiveSmallIntegerField(choices=install_way_choices, verbose_name='安装方式')
 
     def __str__(self):
@@ -116,11 +116,11 @@ class Services(models.Model):
 
 class DBms(models.Model):
     '''db信息关系表'''
-    master = models.ForeignKey(Services, verbose_name='主库')
-    slave = models.OneToOneField(Services, related_name='uuid', verbose_name='从库')
+    main = models.ForeignKey(Services, verbose_name='主库')
+    subordinate = models.OneToOneField(Services, related_name='uuid', verbose_name='从库')
 
     def __str__(self):
-        return "%s-%s" % (self.master, self.slave)
+        return "%s-%s" % (self.main, self.subordinate)
 
     class Meta:
         verbose_name = u'db从主表'

--- a/excute/playbooks/ansible_run.py
+++ b/excute/playbooks/ansible_run.py
@@ -83,16 +83,16 @@ if __name__ == "__main__":
                 {"hostname": "192.168.146.131", "port": "22", "username": "root", "password": "centos", "ip": '192.168.146.131',
                    'vars': {
                        'style': 'server',
-                       'role': 'master',
-                       'slave': '41',
+                       'role': 'main',
+                       'subordinate': '41',
                     }
                 },
                 {"hostname": "192.168.146.132", "port": "22", "username": "root", "password": "centos",
                    "ip": '192.168.146.132',
                    'vars': {
                        'style': 'instance',
-                       'role': 'slave',
-                       'slave': '41',
+                       'role': 'subordinate',
+                       'subordinate': '41',
                     }
                 },
             ],

--- a/excute/playbooks/ansible_start.py
+++ b/excute/playbooks/ansible_start.py
@@ -30,16 +30,16 @@ resource = {
              "ip": '192.168.146.131',
              'vars': {
                  'style': 'server',
-                 'role': 'master',
-                 'slave': '41',
+                 'role': 'main',
+                 'subordinate': '41',
              }
              },
             {"hostname": "192.168.146.132", "port": "22", "username": "root", "password": "centos",
              "ip": '192.168.146.132',
              'vars': {
                  'style': 'instance',
-                 'role': 'slave',
-                 'slave': '41',
+                 'role': 'subordinate',
+                 'subordinate': '41',
              }
              },
         ],

--- a/playbooks/ansible-api3.py
+++ b/playbooks/ansible-api3.py
@@ -73,22 +73,22 @@ if __name__ == "__main__":
         {"hostname": "192.168.1.41", "port": "22", "username": "root", "password": "centos", "ip": '192.168.1.41',
             'vars': {
                 'style': 'server',
-                'role':'master',
-                'slave':'41',
+                'role':'main',
+                'subordinate':'41',
             }
         },
         {"hostname": "192.168.1.44", "port": "22", "username": "root", "password": "centos", "ip": '192.168.1.44',
             'vars': {
                 'style': 'instance',
-                'role':'slave',
-                'slave':'41',
+                'role':'subordinate',
+                'subordinate':'41',
             }
         },
         {"hostname": "192.168.1.45", "port": "22", "username": "root", "password": "Aa123456", "ip": '192.168.1.45',
              'vars': {
                  'style': 'instance',
-                 'role': 'slave',
-                 'slave': '41',
+                 'role': 'subordinate',
+                 'subordinate': '41',
              }
          },
     ]


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.